### PR TITLE
Fix fidx placeholder when sorting is forced.

### DIFF
--- a/snippet.filedir.php
+++ b/snippet.filedir.php
@@ -136,13 +136,20 @@ foreach ($diri as $file) {
                 'date' => date($formatDate, $file->getCTime()),
                 'fidx' => $x
             );
-            $output[$x] = $modx->getChunk($tpl, $itemArray);
+            $imgArray[$x] = $itemArray;
         }
         $x++;
     }
 }
 if ($sort == true)
-    array_multisort($sortArray, ($sortDir === 'ASC' ? SORT_ASC : SORT_DESC), SORT_STRING, $output);
+    array_multisort($sortArray, ($sortDir === 'ASC' ? SORT_ASC : SORT_DESC), SORT_STRING, $imgArray);
+
+$x = 1;
+foreach ($imgArray as $img) {
+    $img['fidx'] = $x;
+    $output[$x] = $modx->getChunk($tpl, $img);
+    $x++;
+}
 
 $output['out'] = $modx->getChunk($tplOut, array(
     'res_filedir' => implode('', $output),


### PR DESCRIPTION
Проблема в том, что сортировка массива с данными происходит уже после парсинга чанков элементов. Если рассматривать вариант использования fidx плейсхолдера как итератора в чанках - то при сортировке он становится неверным! Решение на скорую руку без претензии на красоту.